### PR TITLE
Version command

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -22,7 +22,6 @@ builds:
       -s
       -extldflags '-static'
       -X github.com/docker/index-cli-plugin/internal.version={{.Version}}
-      -X github.com/docker/index-cli-plugin/internal.commit={{.Commit}}
 
 archives:
   - format: tar.gz

--- a/commands/cmd.go
+++ b/commands/cmd.go
@@ -24,6 +24,8 @@ import (
 	"os"
 	"strings"
 
+	"github.com/docker/index-cli-plugin/internal"
+
 	"github.com/moby/term"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -243,7 +245,18 @@ func NewRootCmd(name string, isPlugin bool, dockerCli command.Cli) *cobra.Comman
 		},
 	}
 
-	cmd.AddCommand(loginCommand, logoutCommand, sbomCommand, cveCommand, uploadCommand, diffCommand, watchCommand)
+	versionCommand := &cobra.Command{
+		Use:   "version",
+		Short: "Print version",
+		Args:  cobra.NoArgs,
+		Run: func(_ *cobra.Command, _ []string) {
+			v := internal.FromBuild()
+			fmt.Printf("version: %s (%s - %s)\n", v.Version, v.GoVersion, v.Platform)
+			fmt.Println("git commit:", v.Commit)
+		},
+	}
+
+	cmd.AddCommand(loginCommand, logoutCommand, sbomCommand, cveCommand, uploadCommand, diffCommand, watchCommand, versionCommand)
 	return cmd
 }
 

--- a/internal/version.go
+++ b/internal/version.go
@@ -22,6 +22,7 @@ package internal
 import (
 	"fmt"
 	"runtime"
+	"runtime/debug"
 )
 
 // build-time arguments
@@ -29,6 +30,16 @@ var (
 	version = "n/a"
 	commit  = "n/a"
 )
+
+func init() {
+	if info, ok := debug.ReadBuildInfo(); ok {
+		for _, setting := range info.Settings {
+			if setting.Key == "vcs.revision" {
+				commit = setting.Value
+			}
+		}
+	}
+}
 
 // Version information from build time args and environment
 type Version struct {


### PR DESCRIPTION
Add `version` command to print version, arch, commit.
Commit is now read from Go so it's not necessary anymore to wait for it to be supplied by the outside.

```
❯ docker index version
version: v0.0.27-24-gc3df0d4 (go1.19.4 - darwin/arm64)
git commit: c3df0d46310a32ada580c7b0f53279d669c0d4d4
```