### PR TITLE
Use distribution library to parse references

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/atomist-skills/go-skill v0.0.6-0.20221221214636-a7de163fd901
 	github.com/briandowns/spinner v1.12.0
 	github.com/docker/cli v20.10.21+incompatible
+	github.com/docker/distribution v2.8.1+incompatible
 	github.com/docker/docker v20.10.17+incompatible
 	github.com/dustin/go-humanize v1.0.0
 	github.com/google/go-containerregistry v0.11.0
@@ -71,7 +72,6 @@ require (
 	github.com/dgryski/go-minhash v0.0.0-20170608043002-7fe510aff544 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/dimchansky/utfbom v1.1.1 // indirect
-	github.com/docker/distribution v2.8.1+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.6.4 // indirect
 	github.com/docker/go v1.5.1-1.0.20160303222718-d30aec9fd63c // indirect
 	github.com/docker/go-connections v0.4.0 // indirect

--- a/registry/save_test.go
+++ b/registry/save_test.go
@@ -1,0 +1,99 @@
+package registry
+
+import (
+	"testing"
+)
+
+func Test_mustParseNameAndTag(t *testing.T) {
+	type testCase struct {
+		description string
+		input       string
+		name        string
+		tag         string
+	}
+	testCases := []testCase{
+		{
+			description: "library namespace",
+			input:       "foo:1",
+			name:        "foo",
+			tag:         "1",
+		},
+		{
+			description: "namespace",
+			input:       "foo/bar:2",
+			name:        "foo/bar",
+			tag:         "2",
+		},
+		{
+			description: "registry",
+			input:       "registry.example.com/foo/bar:3",
+			name:        "registry.example.com/foo/bar",
+			tag:         "3",
+		},
+		{
+			description: "registry with port",
+			input:       "localhost:8082/foo/bar:4",
+			name:        "localhost:8082/foo/bar",
+			tag:         "4",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			name, tag := mustParseNameAndTag(tc.input)
+			if name != tc.name {
+				t.Errorf("expected name to be '%s', got '%s'", tc.name, name)
+			}
+			if tag != tc.tag {
+				t.Errorf("expected tag to be '%s', got '%s'", tc.tag, tag)
+			}
+		})
+	}
+}
+
+func Test_mustParseNameAndDigest(t *testing.T) {
+	type testCase struct {
+		description string
+		input       string
+		name        string
+		digest      string
+	}
+	testCases := []testCase{
+		{
+			description: "library namespace",
+			input:       "foo@sha256:544e165df59f0effc3b4aa054712710e0a0913c050d524c44772539c515d1a43",
+			name:        "foo",
+			digest:      "sha256:544e165df59f0effc3b4aa054712710e0a0913c050d524c44772539c515d1a43",
+		},
+		{
+			description: "namespace",
+			input:       "foo/bar@sha256:00b8c9532fbc7894ef92b07322f1943ce23a4935ea1dd4e1a04297831d3aad45",
+			name:        "foo/bar",
+			digest:      "sha256:00b8c9532fbc7894ef92b07322f1943ce23a4935ea1dd4e1a04297831d3aad45",
+		},
+		{
+			description: "registry",
+			input:       "registry.example.com/foo/bar@sha256:57a2a04950c1bd45958947a1b5414558bc2bee863fee519c45da34b398d6d29e",
+			name:        "registry.example.com/foo/bar",
+			digest:      "sha256:57a2a04950c1bd45958947a1b5414558bc2bee863fee519c45da34b398d6d29e",
+		},
+		{
+			description: "registry with port",
+			input:       "localhost:8082/foo/bar@sha256:2adb2c6ade4b433326ea8cddd5c5aa9998d07e8ff603374e3360290807d8c14b",
+			name:        "localhost:8082/foo/bar",
+			digest:      "sha256:2adb2c6ade4b433326ea8cddd5c5aa9998d07e8ff603374e3360290807d8c14b",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			name, digest := mustParseNameAndDigest(tc.input)
+			if name != tc.name {
+				t.Errorf("expected name to be '%s', got '%s'", tc.name, name)
+			}
+			if digest != tc.digest {
+				t.Errorf("expected digest to be '%s', got '%s'", tc.digest, digest)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The current approach of splitting on `:` to get the tag fails when the registry has a port specified. Use the code in `distribution` to parse references instead as it handles all the edge cases.